### PR TITLE
Added Monte Carlo simulation for winning odds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 .DS_Store
 /lib
+.idea/

--- a/README.md
+++ b/README.md
@@ -26,12 +26,21 @@ Call the public `evalHand` method with a single argument, an array of 3, 5, 6 or
   - Suits: c, d, h, s  
 - Numbers corresponding to the values in the [deck](src/constants/deck.const.ts) (currently does not work for 3 card hands)
 
-Call the public `winningOdds` method to estimate the odds of winning a hand given your cards.
+Call the public `winningOddsForPlayer` method to estimate the odds of winning a hand given your cards.
 Example usage:
 ```javascript
-winningOdds(['ah','as'],[],5, 1000) // 0.581
-winningOdds(['ah','as'],['2c','3c','4c','5c'],5, 1000) // 0.03
-winningOdds(['ah','as'],[],2, 1000) // 0.846
+winningOddsForPlayer(['ah','as'],[],5, 1000) // {'winRate':0.56,'split2Rate':0.008,...,'splitNRate':...}
+winningOddsForPlayer(['ah','as'],['2c','3c','4c','5c'],5, 1000) // {'winRate':0.03...}
+winningOddsForPlayer(['ah','as'],[],2, 1000) // {'winRate':0.85,...}
+```
+Call the public `winningHandsForTable` method to get spectator odds for each players hand.
+Example usage:
+```javascript
+winningOddsForTable([['ah','as'],['kd','kh']], [], 2, 1000) // {'players':[{'winRate'...},...]}
+```
+This can be called with partial hands, such as:
+```javascript
+winningOddsForTable([['ah','as'],['kd'],[]], [], 3, 1000)
 ```
 
 _See `src/constants/deck.const.ts` for the full deck_
@@ -85,3 +94,5 @@ To contribute create a pull request from your fork to this repository.
 [David Chen](https://github.com/chenosaurus) - Wrote original poker-evaluator
 
 [Rory Mcgit](https://github.com/rorymcgit) - Made project typescript friendly
+
+[Aaron Segal](https://github.com/asegs) - Added odds calculator

--- a/README.md
+++ b/README.md
@@ -21,10 +21,18 @@ This can evaluate about 22MM hands per second on a quad-core 2.7GHz Macbook Pro.
 ## Usage:
 
 Call the public `evalHand` method with a single argument, an array of 3, 5, 6 or 7 cards as:  
-- strings in the format 'Xy' where X = rank and y = suit). This is case insensitive so xy or XY (or any other combination) work fine too.  
+- Strings in the format 'Xy' where X = rank and y = suit. This is case insensitive so xy or XY (or any other combination) work fine too.  
   - Ranks: A, 1, 2, 3, 4, 5, 6, 7, 8, 9, T, J, Q, K  
   - Suits: c, d, h, s  
-- numbers corresponding to the values in the [deck](src/constants/deck.const.ts) (currently does not work for 3 card hands)
+- Numbers corresponding to the values in the [deck](src/constants/deck.const.ts) (currently does not work for 3 card hands)
+
+Call the public `winningOdds` method to estimate the odds of winning a hand given your cards.
+Example usage:
+```javascript
+winningOdds(['ah','as'],[],5, 1000) // 0.581
+winningOdds(['ah','as'],['2c','3c','4c','5c'],5, 1000) // 0.03
+winningOdds(['ah','as'],[],2, 1000) // 0.846
+```
 
 _See `src/constants/deck.const.ts` for the full deck_
 
@@ -45,7 +53,7 @@ PokerEvaluator.evalHand(['As', 'Ac', 'Qs']);
 //  handName: 'one pair' }
 ```
 
-Importing in Javascript
+Importing in JavaScript:
 ```js
 const PokerEvaluator = require('poker-evaluator');
 ```

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Call the public `evalHand` method with a single argument, an array of 3, 5, 6 or
 - Numbers corresponding to the values in the [deck](src/constants/deck.const.ts) (currently does not work for 3 card hands)
 
 Call the public `winningOddsForPlayer` method to estimate the odds of winning a hand given your cards.
-Example usage:
+This returns a single `PlayerOdds` record.  Example usage:
 ```javascript
-winningOddsForPlayer(['ah','as'],[],5, 1000) // {'winRate':0.56,'split2Rate':0.008,...,'splitNRate':...}
+winningOddsForPlayer(['ah','as'],[],5, 1000) // {'winRate':0.56,'splitRates':[{'rate':0.006, 'ways':2},...{'rate':...,'ways':n}]}
 winningOddsForPlayer(['ah','as'],['2c','3c','4c','5c'],5, 1000) // {'winRate':0.03...}
 winningOddsForPlayer(['ah','as'],[],2, 1000) // {'winRate':0.85,...}
 ```
 Call the public `winningHandsForTable` method to get spectator odds for each players hand.
-Example usage:
+This returns a `TableOdds` record.  Example usage:
 ```javascript
 winningOddsForTable([['ah','as'],['kd','kh']], [], 2, 1000) // {'players':[{'winRate'...},...]}
 ```
@@ -42,6 +42,8 @@ This can be called with partial hands, such as:
 ```javascript
 winningOddsForTable([['ah','as'],['kd'],[]], [], 3, 1000)
 ```
+
+See [odds types](src/types/odds.interface.ts) for the structure of odds.
 
 _See `src/constants/deck.const.ts` for the full deck_
 

--- a/src/constants/deck.const.ts
+++ b/src/constants/deck.const.ts
@@ -54,3 +54,5 @@ export const DECK: Deck = {
   'ah': 51,
   'as': 52
 }
+export const DECK_KEYS = new Set(Object.keys(DECK))
+export const DECK_VALUES = new Set(Object.values(DECK))

--- a/src/poker-evaluator-odds.spec.ts
+++ b/src/poker-evaluator-odds.spec.ts
@@ -1,4 +1,4 @@
-import {winningOdds} from "./poker-evaluator";
+import {winningOddsForPlayer} from "./poker-evaluator";
 
 const DEFAULT_CYCLES = 1000;
 const DEFAULT_PLAYER_COUNT = 5;
@@ -105,9 +105,9 @@ describe('PokerEvaluator', () => {
 
 
 function testHoleCards (cards:string[], expected: number) {
-    expect(withinRange(expected, winningOdds(cards,[], DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES), DEFAULT_CYCLES)).toBeTruthy();
+    expect(withinRange(expected, winningOddsForPlayer(cards,[], DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES)['players'][0]['winRate'], DEFAULT_CYCLES)).toBeTruthy();
 }
 
 function testCommunityCards(hand: string[], community: string[], expected:number) {
-    expect(withinRange(expected, winningOdds(hand, community, DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES), DEFAULT_CYCLES));
+    expect(withinRange(expected, winningOddsForPlayer(hand, community, DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES)['players'][0]['winRate'], DEFAULT_CYCLES));
 }

--- a/src/poker-evaluator-odds.spec.ts
+++ b/src/poker-evaluator-odds.spec.ts
@@ -1,0 +1,44 @@
+import {winningOdds} from "./poker-evaluator";
+
+const BOUND = 4;
+const DEFAULT_CYCLES = 1000;
+const DEFAULT_PLAYER_COUNT = 5;
+
+/**
+ * After extensive testing this function seems to serve as an appropriate upper bound.
+ * Math.E seems a better fit than Math.PI but cases were found where it was exceeded.
+ *
+ * To find a curve for this, the ranges between highest and lowest probability estimate
+ * for a certain cycle count were recorded for cycle counts between 0 and 2500.
+ *
+ * The trend resembled the well-known n/x curve but was softer, so n/sqrt(x) was a better fit.
+ * 4 was selected as a "magic number" here since it safely bounded the most extreme ranges
+ * found at 100 samples.
+ *
+ * Certain hands were more "variable" than others, with subsequent tests yielding wider ranges.
+ * These tended to occur with strong but not dominant hands with larger player counts.
+ *
+ * This should fail extremely rarely in tests, if ever.  If it does, consider increasing the magic number.
+ * It may be too tolerant of slightly off values as it is tuned to include highly unlikely random events,
+ * in order to reduce flakiness.
+ * @param cycles
+ */
+function findVariance(cycles: number):number {
+    return BOUND / Math.sqrt(cycles);
+}
+function withinRange(expected: number, actual: number, cycles: number): boolean {
+    const variance = findVariance(cycles);
+    const diff = Math.abs(expected - actual);
+    return diff < variance/2;
+}
+
+/**
+ * Based on probabilities taken from https://homes.luddy.indiana.edu/kapadia/nofoldem/
+ */
+describe('PokerEvaluator', () => {
+    describe('calculates hole card odds', () => {
+        it('pocket aces', () => {
+            expect(withinRange(0.5578, winningOdds(['as','ac'],[], DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES), DEFAULT_CYCLES)).toBeTruthy();
+        })
+    })
+})

--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -19,18 +19,18 @@ export function evalHand(cards: string[] | number[]): EvaluatedHand {
     && cards.length !== 3) {
     throw new Error(`Hand must be 3, 5, 6, or 7 cards, but ${cards.length} cards were provided`);
   }
-
-  if (cardsAreValidStrings(cards)) {
+  if (cardsAreValidNumbers(cards)) {
+    if (cards.length === 3) {
+      throw new Error(`Please supply 3 card hands as string[] of "cards" only.`);
+    }
+    return evaluate(cards as number[]);
+  }
+  else if (cardsAreValidStrings(cards)) {
     let stringCards = cards as string[];
     if (stringCards.length === 3) { // If a 3 card hand, fill in to make 5 card
       stringCards = ThreeCardConverter.fillHand(stringCards);
     }
     return evaluate(convertCardsToNumbers(stringCards));
-  } else if (cardsAreValidNumbers(cards)) {
-    if (cards.length === 3) {
-      throw new Error(`Please supply 3 card hands as string[] of "cards" only.`);
-    }
-    return evaluate(cards as number[]);
   } else {
     throw new Error(`
       Please supply input as a valid string[] | number[] of "cards".
@@ -121,3 +121,5 @@ function shuffleDeck (deck: number[]) {
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
 }
+
+console.log(winningOdds(['ah','ad'], [], 5, 1000))

--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -88,42 +88,89 @@ function evaluate(cardValues: number[]): EvaluatedHand {
  * for something very unlikely, like a straight flush or four of a kind, running 30000 or more cycles will help in getting
  * odds other than 0, instead yielding the correct ~0.0001.
  */
-export function winningOdds (hand: string[], community: string[], playerCount: number, cycles: number): number {
+export function winningOddsForPlayer (hand: string[], community: string[], playerCount: number, cycles: number): object {
   // Above 23 players, we run out of cards in a deck.  23 * 2 + 5 = 51
   if (playerCount > 23) {
     throw new Error("You may have at most 23 players.")
   }
 
-  const numHand = convertCardsToNumbers(hand)
-  const numCommunity = convertCardsToNumbers(community)
-  const startingDeck = deckWithoutSpecifiedCards([...numHand, ...numCommunity]);
-  let wins = 0;
-  for (let i = 0; i < cycles; i ++ ) {
+  // Hand with no knowledge of other players hands
+  return winningOddsForTable([hand, ...Array(playerCount - 1).fill([])], community, playerCount, cycles);
+}
+
+export function winningOddsForTable(knownPartialHands: string[][], community: string[], playerCount:number, cycles:number): object {
+  const numCommunity = convertCardsToNumbers(community);
+  const numHands = knownPartialHands.map(convertCardsToNumbers);
+  const allHoleCards = numHands.reduce((group, currentHand) => [...group, ...currentHand], []);
+  const startingDeck = deckWithoutSpecifiedCards([...numCommunity, ...allHoleCards]);
+  const startingSplits = [];
+  for (let i = 0; i < playerCount; i++) {
+    startingSplits.push(Array(playerCount - 1).fill(0));
+  }
+  const data = {
+    'wins': Array(playerCount).fill(0),
+    'splits': startingSplits
+  };
+
+  for (let i = 0; i < cycles; i++) {
     shuffleDeck(startingDeck);
     let deckPosition = 0;
     const interimCommunity = [...numCommunity];
 
-    const holeCards = [numHand];
-    for (let p = 1; p < playerCount; p ++) {
-      holeCards.push([startingDeck[deckPosition++], startingDeck[deckPosition++]]);
+    // Fill in players cards from the deck if not provided
+    const holeCards = [];
+    for (let p = 0; p < playerCount; p++) {
+      const card1= numHands[p].length >= 1 ? numHands[p][0] : startingDeck[deckPosition++];
+      const card2 = numHands[p].length == 2 ? numHands[p][1] : startingDeck[deckPosition++];
+      holeCards.push([card1, card2]);
     }
 
     while (interimCommunity.length < 5) {
       interimCommunity.push(startingDeck[deckPosition++]);
     }
 
-    const playerValue = evalHand([...holeCards[0], ...interimCommunity]).value;
-    wins++;
+    // Calculate the ranks of each hand
+    const handValues = holeCards.map(hand => evalHand([...hand, ...interimCommunity]).value);
 
-    for (let p = 1; p < playerCount; p ++) {
-      if (evalHand([...holeCards[p], ...interimCommunity]).value >= playerValue) {
-        wins--;
-        break;
+    // Find the winning hands this round
+    let winningIndexes = [];
+    let bestRank = -1;
+    for (let p = 0; p < playerCount; p ++) {
+      if (handValues[p] > bestRank) {
+        winningIndexes = [p];
+        bestRank = handValues[p];
+      } else if (handValues[p] === bestRank) {
+        winningIndexes.push(p);
       }
     }
+
+    if (winningIndexes.length > 1) {
+      for (let i = 0; i < winningIndexes.length; i++) {
+        // Increment that players split count of this size
+        data['splits'][winningIndexes[i]][winningIndexes.length - 2] += 1;
+      }
+    } else {
+      data['wins'][winningIndexes[0]] += 1;
+    }
+  }
+  return buildPlayerData(data, cycles);
+}
+
+function buildPlayerData(rawData: object, cycles: number): object {
+  const playerCount = rawData['wins'].length;
+  const results = {
+    'players':[]
+  }
+  for (let p = 0; p < playerCount; p++) {
+    const record = {};
+    record['winRate'] = rawData['wins'][p] / cycles;
+    for (let i = 0; i < rawData['splits'][0].length; i++) {
+      record['split' + (i + 2) + "Rate"] = rawData['splits'][p][i] / cycles;
+    }
+    results['players'].push(record);
   }
 
-  return wins / cycles;
+  return results;
 }
 
 /**
@@ -144,3 +191,4 @@ function shuffleDeck (deck: number[]) {
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
 }
+

--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -95,7 +95,7 @@ export function winningOddsForPlayer (hand: string[], community: string[], playe
   }
 
   // Hand with no knowledge of other players hands
-  return winningOddsForTable([hand, ...Array(playerCount - 1).fill([])], community, playerCount, cycles);
+  return winningOddsForTable([hand, ...Array(playerCount - 1).fill([])], community, playerCount, cycles)['players'][0];
 }
 
 export function winningOddsForTable(knownPartialHands: string[][], community: string[], playerCount:number, cycles:number): object {
@@ -191,4 +191,6 @@ function shuffleDeck (deck: number[]) {
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
 }
+
+console.log(winningOddsForTable([['ah','as'],['kd','kh']], [], 2, 1000))
 

--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -72,3 +72,45 @@ function evaluate(cardValues: number[]): EvaluatedHand {
     handName: HAND_TYPES[p >> 12]
   }
 }
+
+export function winningOdds (hand: string[], community: string[], playerCount: number, cycles: number): number {
+  const startingDeck = deckWithoutSpecifiedCards([...hand, ...community]);
+  let wins = 0;
+  for (let i = 0 ; i < cycles ; i ++ ) {
+    shuffleDeck(startingDeck);
+    let deckPosition = 0;
+    const interimCommunity = [...community];
+
+    const holeCards = [hand];
+    for (let p = 1 ; p < playerCount ; p ++) {
+      holeCards.push([startingDeck[deckPosition++], startingDeck[deckPosition++]]);
+    }
+
+    while (interimCommunity.length < 5) {
+      interimCommunity.push(startingDeck[deckPosition++]);
+    }
+
+    const playerValue = evalHand([...holeCards[0], ...interimCommunity]).value;
+    wins ++;
+
+    for (let p = 1 ; p < playerCount ; p ++) {
+      if (evalHand([...holeCards[p], ...interimCommunity]).value >= playerValue) {
+        wins --;
+        break;
+      }
+    }
+  }
+
+  return wins / cycles;
+}
+
+function deckWithoutSpecifiedCards (cards: string[]): string[] {
+  const providedSet = new Set(cards);
+  return Object.keys(DECK).filter(name => !providedSet.has(name));
+}
+function shuffleDeck (deck: string[]) {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+}

--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -191,6 +191,3 @@ function shuffleDeck (deck: number[]) {
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
 }
-
-console.log(winningOddsForTable([['ah','as'],['kd','kh']], [], 2, 1000))
-

--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -74,6 +74,10 @@ function evaluate(cardValues: number[]): EvaluatedHand {
 }
 
 export function winningOdds (hand: string[], community: string[], playerCount: number, cycles: number): number {
+  // Above 23 players, we run out of cards in a deck.  23 * 2 + 5 = 51
+  if (playerCount > 23) {
+    throw new Error("You may have at most 23 players.")
+  }
   const startingDeck = deckWithoutSpecifiedCards([...hand, ...community]);
   let wins = 0;
   for (let i = 0 ; i < cycles ; i ++ ) {

--- a/src/types/odds.interface.ts
+++ b/src/types/odds.interface.ts
@@ -1,0 +1,13 @@
+export type PlayerOdds = {
+    winRate: number;
+    splitRates: Split[];
+}
+
+export type TableOdds = {
+    players: PlayerOdds[];
+}
+
+export type Split = {
+    rate: number;
+    ways: number;
+}


### PR DESCRIPTION
This introduces a second public method on `poker-evaluator`for estimating win probability using a Monte Carlo simulation.  It is explicitly modeled for Texas Hold 'Em.

The API takes the hole cards the player has, the current community cards (if any), the number of players at the table, and the number of trials to run.  The result is a 0-1 probability that the player will win the hands.  

This is a fast and simple implementation of this mechanic.  Performance is influenced mainly by the number of cycles multiplied by the number of players, but also impacted by the number of community cards dealt.  

While a higher number of cycles doesn't lead to dramatically different evaluation, this implementation is capable of considering about 4 million player hands (player count * cycles) per second on my machine.

Example usage:
```javascript
winningOdds(['ah','as'],[],5, 1000) // 0.581

winningOdds(['ah','as'],['2c','3c','4c','5c'],5, 1000) // 0.03

winningOdds(['ah','as'],[],2, 1000) // 0.846
```