### PR TITLE
Updates test to use new odds type

### DIFF
--- a/src/poker-evaluator-odds.spec.ts
+++ b/src/poker-evaluator-odds.spec.ts
@@ -105,9 +105,9 @@ describe('PokerEvaluator', () => {
 
 
 function testHoleCards (cards:string[], expected: number) {
-    expect(withinRange(expected, winningOddsForPlayer(cards,[], DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES)['players'][0]['winRate'], DEFAULT_CYCLES)).toBeTruthy();
+    expect(withinRange(expected, winningOddsForPlayer(cards,[], DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES)['winRate'], DEFAULT_CYCLES)).toBeTruthy();
 }
 
 function testCommunityCards(hand: string[], community: string[], expected:number) {
-    expect(withinRange(expected, winningOddsForPlayer(hand, community, DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES)['players'][0]['winRate'], DEFAULT_CYCLES));
+    expect(withinRange(expected, winningOddsForPlayer(hand, community, DEFAULT_PLAYER_COUNT, DEFAULT_CYCLES)['winRate'], DEFAULT_CYCLES));
 }


### PR DESCRIPTION
Before merging, I had made some changes to the datatypes returned from the individual player odds vs. the table odds.  Seems like I never updated the tests to take the new types into account.  A little embarrassing.