### PR TITLE
Remove debug console.log from production code

### DIFF
--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -191,5 +191,3 @@ function shuffleDeck (deck: number[]) {
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
 }
-
-console.log(winningOddsForPlayer(['ah','as'],[],5, 1000))


### PR DESCRIPTION
When booting up my nestjs server I found a small console.log statement in the terminal which was executing upon importing the lib.